### PR TITLE
Patch CVEs in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.20.10-alpine3.18@sha256:0d6e012ec44ed21993ee2ccf05839844f13347165ce7599a8e8442b02f836b45 as builder
+FROM golang:1.21.12-alpine3.19@sha256:09bee2477a2a56bed70692baa08a394d5b20eebaf6a2e6a620a1eb22200c42c8 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git libstdc++-dev
 
@@ -9,7 +9,7 @@ RUN cd /opt && make ronin
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:3.18@sha256:48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates openssl=3.1.6-r0 busybox=1.36.1-r7
 WORKDIR "/opt"
 
 ENV PASSWORD ''


### PR DESCRIPTION
- Bump `golang` base image to `v1.21.12` (fixes CVE-2024-24790,CVE-2023-45285,CVE-2023-39326,CVE-2024-24789)
- Pin `openssl` to newer version (fixes CVE-2023-5363,CVE-2023-5678,CVE-2023-6129,CVE-2024-0727,CVE-2023-6237,CVE-2024-2511,CVE-2024-4741,CVE-2024-4603,CVE-2024-5535)
- Pin `busybox` to newer version (fixes CVE-2023-42366,CVE-2023-42364,CVE-2023-42365,CVE-2023-42363)